### PR TITLE
Support pass params with object(fixes #24)

### DIFF
--- a/VueCurrencyFilter.js
+++ b/VueCurrencyFilter.js
@@ -42,6 +42,15 @@ const VueCurrencyFilter = {
       // reset first before re-apply config
       _resetAllConfig(options)
 
+      if (typeof _symbol === 'object') {
+        _thousandsSeparator = _symbol.thousandsSeparator
+        _fractionCount = _symbol.fractionCount
+        _fractionSeparator = _symbol.fractionSeparator
+        _symbolPosition = _symbol.symbolPosition
+        _symbolSpacing = _symbol.symbolSpacing
+        _symbol = _symbol.symbol
+      }
+
       // overide again with on the fly config
       if (!_isUndefined(_symbol)) symbol = _symbol
       if (!_isUndefined(_thousandsSeparator)) thousandsSeparator = _thousandsSeparator

--- a/demo/App.vue
+++ b/demo/App.vue
@@ -31,6 +31,11 @@
 					<b class="result__filter">{{ textInput | currency(configSymbol, configSeparator, configFractionCount, configFractionSeparator, configSymbolPosition, configSymbolSpacing) }}</b>
 				</div>
 
+        <div>
+					<b>After filter - Custom Configuration Using Object</b> :
+					<b class="result__filter--object">{{ textInput | currency({ fractionCount: 2, symbol: '¥' }) }}</b>
+				</div>
+
         <InArticleAdsense
             data-ad-client="ca-pub-5442972248172818"
             data-ad-slot="7974047383">

--- a/test/VueCurrencyFilter.spec.js
+++ b/test/VueCurrencyFilter.spec.js
@@ -203,5 +203,18 @@ describe('test VueCurrencyFilter', () => {
     let result = wrapper.find('.result__filter')
     expect(result.text()).toEqual('5.000')
   })
+
+  it('Test config width object', () => {
+    let localVue = createLocalVue()
+
+    localVue.use(VueCurrencyFilter)
+
+    let wrapper = shallow(App, {
+      localVue
+    })
+
+    let result = wrapper.find('.result__filter--object')
+    expect(result.text()).toEqual('¥ 20.000,00')
+  })
 });
 


### PR DESCRIPTION
support `{{ money | currency({ fractionCount: 2 }}}` and not affect basic usage.