### PR TITLE
add feature for multiple global configs

### DIFF
--- a/src/VueCurrencyFilter.js
+++ b/src/VueCurrencyFilter.js
@@ -5,6 +5,7 @@ const VueCurrencyFilter = {
   install(Vue, options) {
 
     const defaultConfig = {
+      name: 'currency',
       symbol: '',
       thousandsSeparator: '.',
       fractionCount: 0,
@@ -14,7 +15,8 @@ const VueCurrencyFilter = {
     }
 
     if (utils.__isNull(options)) options = {}
-    let configs = utils.__defaults(options, defaultConfig)
+    let globalConfigs = utils.__defaults(options, defaultConfig)
+    let { name, ...configs } = globalConfigs
 
     const filterCurrency = function (value,
       _symbol,
@@ -75,7 +77,7 @@ const VueCurrencyFilter = {
       return result
     }
 
-    Vue.filter('currency', filterCurrency)
+    Vue.filter(name, filterCurrency)
     Vue.prototype.$CurrencyFilter = {
       setConfig: (options) => {
         configs = utils.__defaults(options, defaultConfig)


### PR DESCRIPTION
add a property 'name' to the config object passed when registering plugin.
feature requested in issue#41

viz.
```
  Vue.use(VueCurrencyFilter,
  {
    name: 'precision_currency',
    symbol : '$',
    thousandsSeparator: '.',
    fractionCount: 2,
    fractionSeparator: ',',
    symbolPosition: 'front',
    symbolSpacing: true
  })

  Vue.use(VueCurrencyFilter,
  {
    name: 'no_precision_currency',
    symbol : '$',
    thousandsSeparator: '.',
    fractionCount: 0,
    fractionSeparator: ',',
    symbolPosition: 'front',
    symbolSpacing: true
  })

  Vue.use(VueCurrencyFilter,
  {
    symbol : '$',
    thousandsSeparator: '.',
    fractionCount: 1,
    fractionSeparator: ',',
    symbolPosition: 'front',
    symbolSpacing: true
  })
```
now there will be three filters available:
  1. precision_currency
  2. no_precision_currency
  3. currency (default if no 'name' passed)