### PR TITLE
Add target to node as we don't need the Window object.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,6 +8,7 @@ module.exports = {
   entry: {
     VueCurrencyFilter: './src/VueCurrencyFilter.js',
   },
+  target: 'node',
   output: {
     path: path.resolve(__dirname, 'dist'),
     publicPath: '/dist',


### PR DESCRIPTION
This fixes issues with SSR frameworks that don't have the Window object available during the build phase.

Fix #53