### PR TITLE
Avoid unnecessary decimals or use a suffix (fix #59 and #190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Vue.use(VueCurrencyFilter,
   fractionCount: 2,
   fractionSeparator: ',',
   symbolPosition: 'front',
-  symbolSpacing: true
+  symbolSpacing: true,
+  avoidEmptyDecimals: undefined,
 })
 ```
 
@@ -85,7 +86,8 @@ Vue.use(VueCurrencyFilter, [
    fractionCount: 2,
    fractionSeparator: '.',
    symbolPosition: 'front',
-   symbolSpacing: true
+   symbolSpacing: true,
+   avoidEmptyDecimals: '',
  },
  { // default name 'currency_2'
    name: 'currency_2',
@@ -94,7 +96,8 @@ Vue.use(VueCurrencyFilter, [
    fractionCount: 2,
    fractionSeparator: '.',
    symbolPosition: 'front',
-   symbolSpacing: false
+   symbolSpacing: false,
+   avoidEmptyDecimals: '--',
  }
 ])
 ```
@@ -121,7 +124,8 @@ Add `vue-currency-filter/nuxt` to modules section of `nuxt.config.js`
       fractionCount: 2,
       fractionSeparator: '.',
       symbolPosition: 'front',
-      symbolSpacing: true
+      symbolSpacing: true,
+      avoidEmptyDecimals: undefined,
     }],
 
     // for multiple instance
@@ -132,7 +136,8 @@ Add `vue-currency-filter/nuxt` to modules section of `nuxt.config.js`
         fractionCount: 2,
         fractionSeparator: '.',
         symbolPosition: 'front',
-        symbolSpacing: true
+        symbolSpacing: true,
+        avoidEmptyDecimals: '##',
       },
       { // default name 'currency_2'
         name: 'currency_2',
@@ -141,7 +146,8 @@ Add `vue-currency-filter/nuxt` to modules section of `nuxt.config.js`
         fractionCount: 2,
         fractionSeparator: '.',
         symbolPosition: 'front',
-        symbolSpacing: false
+        symbolSpacing: false,
+        avoidEmptyDecimals: '',
       }
     ]],
   ]
@@ -160,7 +166,8 @@ or using external options
       fractionCount: 2,
       fractionSeparator: '.',
       symbolPosition: 'front',
-      symbolSpacing: true
+      symbolSpacing: true,
+      avoidEmptyDecimals: '',
     },
     { // default name 'currency_2'
       name: 'currency_2',
@@ -169,7 +176,8 @@ or using external options
       fractionCount: 2,
       fractionSeparator: '.',
       symbolPosition: 'front',
-      symbolSpacing: false
+      symbolSpacing: false,
+      avoidEmptyDecimals: '##',
     }
   ]
   // or for one filter
@@ -179,7 +187,8 @@ or using external options
     fractionCount: 2,
     fractionSeparator: '.',
     symbolPosition: 'front',
-    symbolSpacing: true
+    symbolSpacing: true,
+    avoidEmptyDecimals: undefined,
   }
 }
 ```
@@ -225,7 +234,8 @@ if (VueCurrencyFilter) {
     fractionCount: 0,
     fractionSeparator: ".",
     symbolPosition: "front",
-    symbolSpacing: false
+    symbolSpacing: false,
+    avoidEmptyDecimals: '',
   })
 }
 
@@ -259,7 +269,8 @@ configFractionSeparator, configSymbolPosition, configSymbolSpacing)}}
   fractionCount: '',
   fractionSeparator: '',
   symbolPosition: '',
-  symbolSpacing: ''
+  symbolSpacing: '',
+  avoidEmptyDecimals: undefined,
 })}}
 </span>
 ```
@@ -274,7 +285,8 @@ configFractionSeparator, configSymbolPosition, configSymbolSpacing)}}
   fractionCount: 'number (default : 0)',
   fractionSeparator: 'string (default: ",")',
   symbolPosition: 'string (default: front)',
-  symbolSpacing: 'boolean (default: true)'
+  symbolSpacing: 'boolean (default: true)',
+  avoidEmptyDecimals: 'string (default: undefined)',
 }
 ```
 
@@ -299,15 +311,50 @@ describe("test myComponent", () => {
       fractionCount: 2,
       fractionSeparator: ".",
       symbolPosition: "front",
-      symbolSpacing: true
+      symbolSpacing: true,
+      avoidEmptyDecimals: undefined,
     });
 
-    const wrapper = shallowMount(Component, {
+    let wrapper = shallowMount(Component, {
       localVue
     });
 
     const result = wrapper.find(".curr");
     expect(result.text()).toEqual("$ 1,000.00");
+    
+    localVue.use(VueCurrencyFilter, {
+      symbol: "$",
+      thousandsSeparator: ",",
+      fractionCount: 2,
+      fractionSeparator: ".",
+      symbolPosition: "front",
+      symbolSpacing: true,
+      avoidEmptyDecimals: '',
+    });
+
+    wrapper = shallowMount(Component, {
+      localVue
+    });
+
+    const result = wrapper.find(".curr");
+    expect(result.text()).toEqual("$ 1,000");
+    
+    localVue.use(VueCurrencyFilter, {
+      symbol: "$",
+      thousandsSeparator: ",",
+      fractionCount: 2,
+      fractionSeparator: ".",
+      symbolPosition: "front",
+      symbolSpacing: true,
+      avoidEmptyDecimals: '##',
+    });
+
+    wrapper = shallowMount(Component, {
+      localVue
+    });
+
+    const result = wrapper.find(".curr");
+    expect(result.text()).toEqual("$ 1,000.##");
   });
 });
 ```

--- a/packages/demo/src/views/Home.vue
+++ b/packages/demo/src/views/Home.vue
@@ -195,6 +195,59 @@
       <div class="field is-horizontal">
         <div class="field-label is-normal">
           <label class="label">
+            Avoid empty decimals:
+          </label>
+        </div>
+        <div class="field-body">
+          <div class="field">
+            <div class="control">
+              <label class="radio">
+                <input
+                  id="chk-form-5"
+                  v-model="configUseAvoidEmptyDecimals"
+                  type="radio"
+                  name="chk-avoidemptydecimals"
+                  :value="true">
+                  Custom string instead of decimal zeros
+              </label>
+              <label class="radio">
+                <input
+                  id="chk-form-5"
+                  v-model="configUseAvoidEmptyDecimals"
+                  type="radio"
+                  name="chk-avoidemptydecimals"
+                  :value="false">
+                  Display decimal zeros
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="field is-horizontal" v-if="configUseAvoidEmptyDecimals">
+        <div class="field-label is-normal">
+          <label class="label">
+            Avoid empty decimals string:
+          </label>
+        </div>
+        <div class="field-body">
+          <div class="field">
+            <div class="control">
+              <label class="radio">
+                <input
+                  v-model="configAvoidEmptyDecimals"
+                  type="text"
+                  class="input"
+                  placeholder="empty decimals string">
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="field is-horizontal">
+        <div class="field-label is-normal">
+          <label class="label">
             Currency:
           </label>
         </div>
@@ -240,7 +293,7 @@
           style="align-items: flex-end;">
           <div class="field" style="text-align: left">
             <b class="subtitle result__filter">
-              {{ textInput | currency(configSymbol, configSeparator, configFractionCount, configFractionSeparator, configSymbolPosition, configSymbolSpacing) }}
+              {{ textInput | currency(configSymbol, configSeparator, configFractionCount, configFractionSeparator, configSymbolPosition, configSymbolSpacing, configUseAvoidEmptyDecimals ? configAvoidEmptyDecimals : undefined) }}
             </b>
           </div>
         </div>
@@ -356,6 +409,8 @@ export default {
       configFractionSeparator: ',',
       configSymbolPosition: 'front',
       configSymbolSpacing: true,
+      configUseAvoidEmptyDecimals: false,
+      configAvoidEmptyDecimals: '',
       templateDownload: `
 # NPM
 npm install vue-currency-filter

--- a/packages/vue-currency-filter/src/index.ts
+++ b/packages/vue-currency-filter/src/index.ts
@@ -10,7 +10,8 @@ const defaultConfig: currencyOptions = {
   fractionCount: 0,
   fractionSeparator: ',',
   symbolPosition: 'front',
-  symbolSpacing: true
+  symbolSpacing: true,
+  avoidEmptyDecimals: undefined,
 }
 
 const VueCurrencyFilter: PluginObject<currencyOptions[] | currencyOptions> = {
@@ -26,7 +27,8 @@ const VueCurrencyFilter: PluginObject<currencyOptions[] | currencyOptions> = {
                                        _fractionCount?: number,
                                        _fractionSeparator?: string,
                                        _symbolPosition?: string,
-                                       _symbolSpacing?: boolean): string | number {
+                                       _symbolSpacing?: boolean,
+                                       _avoidEmptyDecimals?: string): string | number {
 
         let runtimeConfig = __defaults({
           symbol: _symbol,
@@ -34,7 +36,8 @@ const VueCurrencyFilter: PluginObject<currencyOptions[] | currencyOptions> = {
           fractionCount: _fractionCount,
           fractionSeparator: _fractionSeparator,
           symbolPosition: _symbolPosition,
-          symbolSpacing: _symbolSpacing
+          symbolSpacing: _symbolSpacing,
+          avoidEmptyDecimals: _avoidEmptyDecimals
         }, configs)
 
         if (typeof _symbol === 'object') {
@@ -70,7 +73,8 @@ const VueCurrencyFilter: PluginObject<currencyOptions[] | currencyOptions> = {
           symbol: runtimeConfig.symbol,
           precision: runtimeConfig.fractionCount,
           thousand: runtimeConfig.thousandsSeparator,
-          decimal: runtimeConfig.fractionSeparator
+          decimal: runtimeConfig.fractionSeparator,
+          avoidEmptyDecimals: runtimeConfig.avoidEmptyDecimals,
         })
 
         if (isNegative) {

--- a/packages/vue-currency-filter/src/types/index.ts
+++ b/packages/vue-currency-filter/src/types/index.ts
@@ -5,7 +5,8 @@ export interface currencyOptions {
   fractionCount?: number,
   fractionSeparator?: string,
   symbolPosition?: string,
-  symbolSpacing?: boolean
+  symbolSpacing?: boolean,
+  avoidEmptyDecimals?: string,
 }
 
 export interface CurrencyFilterMethodInstance {
@@ -17,5 +18,6 @@ export interface CurrencyFilterMethodInstance {
           _fractionCount?: number,
           _fractionSeparator?: string,
           _symbolPosition?: string,
-          _symbolSpacing?: boolean): string
+          _symbolSpacing?: boolean,
+          avoidEmptyDecimals?: string): string
 }


### PR DESCRIPTION
As the title suggests.
Thanks to this, you can set a `avoidEmptyDecimals` string to use as a suffix in case decimals are zeros.
If you set an empty string, it does not display the decimal separator nor the zeros.
If `avoidEmptyDecimals` is not set, so null or undefined (which is the default) it follows the current behaviour.